### PR TITLE
Refactoring serializers to be grouped in folders

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,12 +8,12 @@ class Api::V1::ArticlesController < ApplicationController
                else
                  Article.all
                end
-    render json: articles, each_serializer: ArticlesIndexSerializer
+    render json: articles, each_serializer: Articles::IndexSerializer
   end
 
   def show
     article = Article.find(params[:id])
-    render json: article, serializer: ArticleShowSerializer
+    render json: article, serializer: Articles::ShowSerializer
   end
 
   private

--- a/app/serializers/articles/index_serializer.rb
+++ b/app/serializers/articles/index_serializer.rb
@@ -1,0 +1,3 @@
+class Articles::IndexSerializer < ActiveModel::Serializer
+  attributes :id, :title, :teaser, :category
+end

--- a/app/serializers/articles/show_serializer.rb
+++ b/app/serializers/articles/show_serializer.rb
@@ -1,3 +1,3 @@
-class ArticleShowSerializer < ActiveModel::Serializer
+class Articles::ShowSerializer < ActiveModel::Serializer
   attributes :id, :title, :teaser, :content, :category
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,3 +1,0 @@
-class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :category
-end


### PR DESCRIPTION
This PR contains:
[PT](https://www.pivotaltracker.com/story/show/175217638)

- It's a better practice to store serializers in separate folders